### PR TITLE
end_cycles -> elapsed_cycles

### DIFF
--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -20,7 +20,7 @@ pub fn draw_stdout(spans: Vec<minitrace::SpanSet>) {
 
     for span in spans {
         let start = span.begin_cycles;
-        let end = span.end_cycles;
+        let end = start + span.elapsed_cycles;
 
         if end > max_end {
             max_end = end;
@@ -57,6 +57,7 @@ pub fn draw_stdout(spans: Vec<minitrace::SpanSet>) {
 
     let root = root.expect("can not find root");
     let root_cycles = root_cycles.unwrap();
+
     for (_, (start, _)) in spans_map.iter_mut() {
         *start -= root_cycles;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub struct Span {
     pub link: Link,
     // TODO: add cargo feature to allow altering to ns
     pub begin_cycles: u64,
-    pub end_cycles: u64,
+    pub elapsed_cycles: u64,
     pub event: u32,
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,7 +5,6 @@ use core::arch::x86::_rdtsc;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::_rdtsc;
 
-
 lazy_static::lazy_static! {
     static ref CYCLES_PER_SEC: u64 = init_cycles_per_sec();
     static ref OFFSET_INSTANT: std::time::Instant = std::time::Instant::now();
@@ -28,7 +27,7 @@ pub(crate) fn monotonic_cycles() -> u64 {
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline]
 pub(crate) fn monotonic_cycles() -> u64 {
-    // There is a virtual generic 1GHz processor ticking every ns 
+    // There is a virtual generic 1GHz processor ticking every ns
     // called nanosecond clock.
     (*OFFSET_INSTANT).elapsed().as_nanos() as u64
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -5,6 +5,7 @@ use core::arch::x86::_rdtsc;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::_rdtsc;
 
+
 lazy_static::lazy_static! {
     static ref CYCLES_PER_SEC: u64 = init_cycles_per_sec();
     static ref OFFSET_INSTANT: std::time::Instant = std::time::Instant::now();
@@ -27,7 +28,14 @@ pub(crate) fn monotonic_cycles() -> u64 {
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline]
 pub(crate) fn monotonic_cycles() -> u64 {
+    // There is a virtual generic 1GHz processor ticking every ns 
+    // called nanosecond clock.
     (*OFFSET_INSTANT).elapsed().as_nanos() as u64
+}
+
+#[inline]
+pub(crate) fn elapsed_cycles(from: u64) -> u64 {
+    monotonic_cycles().checked_sub(from).unwrap_or(0)
 }
 
 #[inline]
@@ -74,6 +82,6 @@ fn init_cycles_per_sec() -> u64 {
 
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 fn init_cycles_per_sec() -> u64 {
-    // FIXME this value is a bogus placeholder
+    // The nanosecond clock ticks 1,000,000,000 times every second.
     1_000_000_000
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -34,7 +34,7 @@ pub(crate) fn monotonic_cycles() -> u64 {
 
 #[inline]
 pub(crate) fn elapsed_cycles(from: u64) -> u64 {
-    monotonic_cycles().checked_sub(from).unwrap_or(0)
+    monotonic_cycles().saturating_sub(from)
 }
 
 #[inline]

--- a/src/trace_local.rs
+++ b/src/trace_local.rs
@@ -72,7 +72,7 @@ impl LocalTraceGuard {
             id,
             link,
             begin_cycles: crate::time::monotonic_cycles(),
-            end_cycles: 0,
+            elapsed_cycles: 0,
             event: event.into(),
         });
 
@@ -93,7 +93,8 @@ impl Drop for LocalTraceGuard {
     fn drop(&mut self) {
         let tl = unsafe { &mut *self.trace_local };
 
-        tl.span_stack[self.start_index].end_cycles = crate::time::monotonic_cycles();
+        tl.span_stack[self.start_index].elapsed_cycles =
+            crate::time::elapsed_cycles(tl.span_stack[self.start_index].begin_cycles);
         let id = tl.span_stack[self.start_index].id;
 
         assert_eq!(tl.enter_stack.pop().unwrap(), id, "corrupted stack");
@@ -159,7 +160,7 @@ impl SpanGuard {
             id,
             link: crate::Link::Parent { id: parent },
             begin_cycles: crate::time::monotonic_cycles(),
-            end_cycles: 0,
+            elapsed_cycles: 0,
             event,
         });
 
@@ -170,7 +171,8 @@ impl SpanGuard {
 impl Drop for SpanGuard {
     fn drop(&mut self) {
         let tl = unsafe { &mut *self.trace_local };
-        tl.span_stack[self.index].end_cycles = crate::time::monotonic_cycles();
+        tl.span_stack[self.index].elapsed_cycles =
+            crate::time::elapsed_cycles(tl.span_stack[self.index].begin_cycles);
         tl.enter_stack.pop();
     }
 }


### PR DESCRIPTION
Signed-off-by: zhongzc <zhongzc_arch@outlook.com>

Small numbers are more varint compression friendly.