### PR TITLE
Support property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,12 @@ jobs:
     - name: Lints
       run: cargo clippy --all-targets --all-features -- --deny warnings
     - name: Build
-      run: cargo build --verbose --all
+      run: cargo build --workspace --all-targets
     - name: Run tests
-      run: cargo test --verbose --all
+      run: cargo test --workspace --all-targets
     - name: Run benches
-      run: cargo bench --verbose --all
+      run: cargo bench --workspace --all-targets
     - name: Run examples
       run: |
-        cargo run --example asynchronous --verbose
-        cargo run --example synchronous --verbose
+        cargo run --example asynchronous
+        cargo run --example synchronous

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       run: cargo clippy --all-targets --all-features -- --deny warnings
     - name: Build
       run: cargo build --workspace --all-targets
-    - name: Run tests
-      run: cargo test --workspace --all-targets
+    # - name: Run tests
+    #   run: cargo test --workspace --all-targets
     - name: Run benches
       run: cargo bench --workspace --all-targets
     - name: Run examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       run: cargo clippy --all-targets --all-features -- --deny warnings
     - name: Build
       run: cargo build --workspace --all-targets
-    # - name: Run tests
-    #   run: cargo test --workspace --all-targets
+    - name: Run tests
+      run: cargo test --workspace --all-targets
     - name: Run benches
       run: cargo bench --workspace --all-targets
     - name: Run examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 [[package]]
 name = "minstant"
 version = "0.0.0"
-source = "git+https://github.com/zhongzc/minstant.git#3b40d95c7879b132778a8058d50fbc70b531fef8"
+source = "git+https://github.com/zhongzc/minstant.git#48a631c19532d05e32420262779a51621b509021"
 dependencies = [
  "lazy_static",
  "libc",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ let task = async {
     // current future ...
 
     // should drop here or it would fail compilation
-    // because local guards cannot cross-thread.
+    // because local guards cannot across thread.
     drop(guard);
 
     async {

--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -27,7 +27,9 @@ fn parallel_job() -> Vec<tokio::task::JoinHandle<()>> {
 }
 
 async fn iter_job(iter: u64) {
-    std::thread::sleep(std::time::Duration::from_millis(iter * 10));
+    for _ in 0..iter * 10000 {
+        std::process::id();
+    }
     tokio::task::yield_now().await;
     other_job().await;
 }
@@ -38,7 +40,10 @@ async fn other_job() {
         if i == 10 {
             tokio::task::yield_now().await;
         }
-        std::thread::sleep(std::time::Duration::from_millis(1))
+
+        for _ in 0..1000 {
+            std::process::id();
+        }
     }
 }
 

--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -27,9 +27,7 @@ fn parallel_job() -> Vec<tokio::task::JoinHandle<()>> {
 }
 
 async fn iter_job(iter: u64) {
-    for _ in 0..iter * 10000 {
-        std::process::id();
-    }
+    std::thread::sleep(std::time::Duration::from_millis(iter * 10));
     tokio::task::yield_now().await;
     other_job().await;
 }
@@ -40,10 +38,7 @@ async fn other_job() {
         if i == 10 {
             tokio::task::yield_now().await;
         }
-
-        for _ in 0..1000 {
-            std::process::id();
-        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
     }
 }
 

--- a/examples/synchronous.rs
+++ b/examples/synchronous.rs
@@ -4,17 +4,13 @@ mod common;
 
 fn func1(i: u64) {
     let _guard = minitrace::new_span(0u32);
-    for _ in 0..i * 1000 {
-        std::process::id();
-    }
+    std::thread::sleep(std::time::Duration::from_millis(i));
     func2(i);
 }
 
 #[minitrace::trace(0u32)]
 fn func2(i: u64) {
-    for _ in 0..i * 1000 {
-        std::process::id();
-    }
+    std::thread::sleep(std::time::Duration::from_millis(i));
 }
 
 fn main() {

--- a/examples/synchronous.rs
+++ b/examples/synchronous.rs
@@ -4,13 +4,17 @@ mod common;
 
 fn func1(i: u64) {
     let _guard = minitrace::new_span(0u32);
-    std::thread::sleep(std::time::Duration::from_millis(i));
+    for _ in 0..i * 1000 {
+        std::process::id();
+    }
     func2(i);
 }
 
 #[minitrace::trace(0u32)]
 fn func2(i: u64) {
-    std::thread::sleep(std::time::Duration::from_millis(i));
+    for _ in 0..i * 1000 {
+        std::process::id();
+    }
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod tests;
 
 pub use minitrace_attribute::{trace, trace_async};
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct TraceDetails {
     /// The start time of the whole tracing process that is the time
     /// when calling `trace_enable`
@@ -55,7 +55,14 @@ pub enum Link {
     Continue { id: u64 },
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone)]
+pub struct Property {
+    pub span_id: u64,
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
 pub struct SpanSet {
     /// The create time of the span set. Used to calculate
     /// the waiting time of async task.
@@ -66,4 +73,7 @@ pub struct SpanSet {
 
     /// Span collection
     pub spans: Vec<Span>,
+
+    /// Property collection
+    pub properties: Vec<Property>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,7 @@ pub enum Link {
 #[derive(Debug, Clone)]
 pub struct Property {
     pub span_id: u64,
-    pub key: Vec<u8>,
-    pub value: Vec<u8>,
+    pub payload: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,19 @@ pub enum Link {
     Continue { id: u64 },
 }
 
+/// span id -> property
+/// 10      -> b"123"
+/// 10      -> b"!@$#$%"
+/// 12      -> b"abcd"
+/// 14      -> b"xyz"
+///
+/// would be stored as:
+///
+/// span_id_to_len: [(10, 3), (10, 6), (12, 4), (14, 3)]
+/// payload: b"123!@$#$%abcdxyz"
 #[derive(Debug, Clone)]
-pub struct Property {
-    pub span_id: u64,
+pub struct Properties {
+    pub span_id_to_len: Vec<(u64, u64)>,
     pub payload: Vec<u8>,
 }
 
@@ -74,5 +84,5 @@ pub struct SpanSet {
     pub spans: Vec<Span>,
 
     /// Property collection
-    pub properties: Vec<Property>,
+    pub properties: Properties,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,16 +55,33 @@ pub enum Link {
     Continue { id: u64 },
 }
 
+/// Properties can used to attach some information about tracing context
+/// to current span, e.g. host of the request, CPU usage.
+///
+/// Usage:
+/// ```rust
+/// {
+///     let _guard = minitrace::new_span(event_id);
+///     minitrace::property(b"host:127.0.0.1");
+///     minitrace::property(b"cpu_usage:42%");
+/// }
+/// ```
+///
+/// Every property will relate to a span. Logically properties are a sequence
+/// of (span id, property) pairs:
+/// ```
 /// span id -> property
 /// 10      -> b"123"
 /// 10      -> b"!@$#$%"
 /// 12      -> b"abcd"
 /// 14      -> b"xyz"
+/// ```
 ///
-/// would be stored as:
-///
+/// and will be stored into `Properties` struct as:
+/// ```
 /// span_id_to_len: [(10, 3), (10, 6), (12, 4), (14, 3)]
 /// payload: b"123!@$#$%abcdxyz"
+/// ```
 #[derive(Debug, Clone)]
 pub struct Properties {
     pub span_id_to_len: Vec<(u64, u64)>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -233,7 +233,7 @@ fn trace_collect_ahead() {
     let wg = crossbeam::sync::WaitGroup::new();
     let wg1 = wg.clone();
     let handle = crate::trace_crossthread();
-    std::thread::spawn(move || {
+    let jh = std::thread::spawn(move || {
         let mut handle = handle;
         let guard = handle.trace_enable(2u32);
 
@@ -251,6 +251,8 @@ fn trace_collect_ahead() {
     assert_eq!(spans.len(), 2);
     assert_eq!(&spans, &[(0, None), (1, Some(0)),]);
     check_clear();
+
+    jh.join().unwrap();
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,7 +55,7 @@ where
 
 fn check_clear() {
     check_trace_local(|tl| {
-        tl.span_stack.is_empty() && tl.enter_stack.is_empty() && tl.cur_collector.is_none()
+        tl.spans.is_empty() && tl.enter_stack.is_empty() && tl.cur_collector.is_none()
     });
 }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -52,8 +52,8 @@ pub fn trace_crossthread() -> crate::trace_crossthread::CrossthreadTrace {
     crate::trace_crossthread::CrossthreadTrace::new()
 }
 
-/// The property is in bytes format, so it is not limited to be a key-value pair but 
-/// anything intend. However, the downside of flexibility is that encoding and decoding 
+/// The property is in bytes format, so it is not limited to be a key-value pair but
+/// anything intended. However, the downside of flexibility is that encoding and decoding
 /// should be handled handly.
 #[inline]
 pub fn property(p: &[u8]) {

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -52,6 +52,9 @@ pub fn trace_crossthread() -> crate::trace_crossthread::CrossthreadTrace {
     crate::trace_crossthread::CrossthreadTrace::new()
 }
 
+/// The property is in bytes format, so it is not limited to be a key-value pair but 
+/// anything intend. However, the downside of flexibility is that encoding and decoding 
+/// should be handled handly.
 #[inline]
 pub fn property(p: &[u8]) {
     crate::trace_local::append_property(p);

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -51,3 +51,8 @@ pub fn new_span<T: Into<u32>>(event: T) -> Option<crate::trace_local::SpanGuard>
 pub fn trace_crossthread() -> crate::trace_crossthread::CrossthreadTrace {
     crate::trace_crossthread::CrossthreadTrace::new()
 }
+
+#[inline]
+pub fn property(p: &[u8]) {
+    crate::trace_local::append_property(p);
+}

--- a/src/trace_local.rs
+++ b/src/trace_local.rs
@@ -146,6 +146,11 @@ impl Drop for LocalTraceGuard {
             });
         }
 
+        tl.spans.truncate(self.span_start_index);
+        tl.property_id_to_len.truncate(self.property_start_index);
+        tl.property_payload
+            .truncate(self.property_payload_start_index);
+
         // try to shrink all vectors in case they take up too much memory
         if tl.spans.capacity() > INIT_NORMAL_LEN && tl.spans.len() < INIT_NORMAL_LEN / 2 {
             tl.spans.shrink_to(INIT_NORMAL_LEN);

--- a/src/trace_local.rs
+++ b/src/trace_local.rs
@@ -144,12 +144,12 @@ impl Drop for LocalTraceGuard {
                     payload: property_payload,
                 },
             });
+        } else {
+            tl.spans.truncate(self.span_start_index);
+            tl.property_id_to_len.truncate(self.property_start_index);
+            tl.property_payload
+                .truncate(self.property_payload_start_index);
         }
-
-        tl.spans.truncate(self.span_start_index);
-        tl.property_id_to_len.truncate(self.property_start_index);
-        tl.property_payload
-            .truncate(self.property_payload_start_index);
 
         // try to shrink all vectors in case they take up too much memory
         if tl.spans.capacity() > INIT_NORMAL_LEN && tl.spans.len() < INIT_NORMAL_LEN / 2 {

--- a/src/trace_local.rs
+++ b/src/trace_local.rs
@@ -124,17 +124,17 @@ impl Drop for LocalTraceGuard {
         let id = tl.spans[self.span_start_index].id;
         assert_eq!(tl.enter_stack.pop().unwrap(), id, "corrupted stack");
 
+        let spans = tl.spans.split_off(self.span_start_index);
+        let property_id_to_len = tl.property_id_to_len.split_off(self.property_start_index);
+        let property_payload = tl
+            .property_payload
+            .split_off(self.property_payload_start_index);
+
         if !self
             .collector
             .closed
             .load(std::sync::atomic::Ordering::SeqCst)
         {
-            let spans = tl.spans.split_off(self.span_start_index);
-            let property_id_to_len = tl.property_id_to_len.split_off(self.property_start_index);
-            let property_payload = tl
-                .property_payload
-                .split_off(self.property_payload_start_index);
-
             self.collector.queue.push(crate::SpanSet {
                 create_time_ns: self.create_time_ns,
                 start_time_ns: self.start_time_ns,

--- a/src/trace_local.rs
+++ b/src/trace_local.rs
@@ -108,6 +108,7 @@ impl Drop for LocalTraceGuard {
                 create_time_ns: self.create_time_ns,
                 start_time_ns: self.start_time_ns,
                 spans: tl.span_stack[self.start_index..].to_vec(),
+                properties: vec![],
             });
         }
 

--- a/src/trace_local.rs
+++ b/src/trace_local.rs
@@ -124,17 +124,17 @@ impl Drop for LocalTraceGuard {
         let id = tl.spans[self.span_start_index].id;
         assert_eq!(tl.enter_stack.pop().unwrap(), id, "corrupted stack");
 
-        let spans = tl.spans.split_off(self.span_start_index);
-        let property_id_to_len = tl.property_id_to_len.split_off(self.property_start_index);
-        let property_payload = tl
-            .property_payload
-            .split_off(self.property_payload_start_index);
-
         if !self
             .collector
             .closed
             .load(std::sync::atomic::Ordering::SeqCst)
         {
+            let spans = tl.spans.split_off(self.span_start_index);
+            let property_id_to_len = tl.property_id_to_len.split_off(self.property_start_index);
+            let property_payload = tl
+                .property_payload
+                .split_off(self.property_payload_start_index);
+
             self.collector.queue.push(crate::SpanSet {
                 create_time_ns: self.create_time_ns,
                 start_time_ns: self.start_time_ns,

--- a/src/trace_local.rs
+++ b/src/trace_local.rs
@@ -2,10 +2,15 @@
 
 type SpanId = u64;
 
+const INIT_NORMAL_LEN: usize = 1024;
+const INIT_BYTES_LEN: usize = 16384;
+
 thread_local! {
     pub(crate) static TRACE_LOCAL: std::cell::UnsafeCell<TraceLocal> = std::cell::UnsafeCell::new(TraceLocal {
-        span_stack: Vec::with_capacity(1024),
-        enter_stack: Vec::with_capacity(1024),
+        spans: Vec::with_capacity(INIT_NORMAL_LEN),
+        enter_stack: Vec::with_capacity(INIT_NORMAL_LEN),
+        property_id_to_len: Vec::with_capacity(INIT_NORMAL_LEN),
+        property_payload: Vec::with_capacity(INIT_BYTES_LEN),
         id_prefix: next_global_id_prefix(),
         id_suffix: 0,
         cur_collector: None,
@@ -13,8 +18,10 @@ thread_local! {
 }
 
 pub(crate) struct TraceLocal {
-    pub(crate) span_stack: Vec<crate::Span>,
+    pub(crate) spans: Vec<crate::Span>,
     pub(crate) enter_stack: Vec<SpanId>,
+    pub(crate) property_id_to_len: Vec<(SpanId, u64)>,
+    pub(crate) property_payload: Vec<u8>,
     pub(crate) id_prefix: u32,
     pub(crate) id_suffix: u32,
     pub(crate) cur_collector: Option<std::sync::Arc<crate::collector::CollectorInner>>,
@@ -30,9 +37,12 @@ fn next_global_id_prefix() -> u32 {
 pub struct LocalTraceGuard {
     collector: std::sync::Arc<crate::collector::CollectorInner>,
     trace_local: *mut TraceLocal,
-    start_index: usize,
     create_time_ns: u64,
     start_time_ns: u64,
+
+    span_start_index: usize,
+    property_start_index: usize,
+    property_payload_start_index: usize,
 }
 
 impl !Sync for LocalTraceGuard {}
@@ -66,9 +76,11 @@ impl LocalTraceGuard {
         };
 
         tl.enter_stack.push(id);
-        let start_index = tl.span_stack.len();
+        let span_start_index = tl.spans.len();
+        let property_start_index = tl.property_id_to_len.len();
+        let property_payload_start_index = tl.property_payload.len();
 
-        tl.span_stack.push(crate::Span {
+        tl.spans.push(crate::Span {
             id,
             link,
             begin_cycles: minstant::now(),
@@ -80,7 +92,9 @@ impl LocalTraceGuard {
             Self {
                 collector,
                 trace_local,
-                start_index,
+                span_start_index,
+                property_start_index,
+                property_payload_start_index,
                 create_time_ns,
                 start_time_ns,
             },
@@ -93,10 +107,12 @@ impl Drop for LocalTraceGuard {
     fn drop(&mut self) {
         let tl = unsafe { &mut *self.trace_local };
 
-        tl.span_stack[self.start_index].elapsed_cycles =
-            minstant::now().saturating_sub(tl.span_stack[self.start_index].begin_cycles);
-        let id = tl.span_stack[self.start_index].id;
+        // fill the elapsed cycles of the first span
+        tl.spans[self.span_start_index].elapsed_cycles =
+            minstant::now().saturating_sub(tl.spans[self.span_start_index].begin_cycles);
 
+        // check if enter stack is corrupted
+        let id = tl.spans[self.span_start_index].id;
         assert_eq!(tl.enter_stack.pop().unwrap(), id, "corrupted stack");
 
         if !self
@@ -104,20 +120,40 @@ impl Drop for LocalTraceGuard {
             .closed
             .load(std::sync::atomic::Ordering::SeqCst)
         {
+            let spans = tl.spans.split_off(self.span_start_index);
+            let property_id_to_len = tl.property_id_to_len.split_off(self.property_start_index);
+            let property_payload = tl
+                .property_payload
+                .split_off(self.property_payload_start_index);
+
             self.collector.queue.push(crate::SpanSet {
                 create_time_ns: self.create_time_ns,
                 start_time_ns: self.start_time_ns,
-                spans: tl.span_stack[self.start_index..].to_vec(),
-                properties: vec![],
+                spans,
+                properties: crate::Properties {
+                    span_id_to_len: property_id_to_len,
+                    payload: property_payload,
+                },
             });
         }
 
-        tl.span_stack.truncate(self.start_index);
-        if tl.span_stack.capacity() > 1024 && tl.span_stack.len() < 512 {
-            tl.span_stack.shrink_to(1024);
+        // shrink all vectors in case they take up too much memory
+        if tl.spans.capacity() > INIT_NORMAL_LEN && tl.spans.len() < INIT_NORMAL_LEN / 2 {
+            tl.spans.shrink_to(INIT_NORMAL_LEN);
         }
-        if tl.enter_stack.capacity() > 1024 && tl.enter_stack.len() < 512 {
-            tl.enter_stack.shrink_to(1024);
+        if tl.enter_stack.capacity() > INIT_NORMAL_LEN && tl.enter_stack.len() < INIT_NORMAL_LEN / 2
+        {
+            tl.enter_stack.shrink_to(INIT_NORMAL_LEN);
+        }
+        if tl.property_id_to_len.capacity() > INIT_NORMAL_LEN
+            && tl.property_id_to_len.len() < INIT_NORMAL_LEN / 2
+        {
+            tl.property_id_to_len.shrink_to(INIT_NORMAL_LEN);
+        }
+        if tl.property_payload.capacity() > INIT_BYTES_LEN
+            && tl.property_payload.len() < INIT_BYTES_LEN / 2
+        {
+            tl.property_payload.shrink_to(INIT_BYTES_LEN);
         }
 
         tl.cur_collector = None;
@@ -141,7 +177,7 @@ impl SpanGuard {
             return None;
         }
 
-        let index = tl.span_stack.len();
+        let index = tl.spans.len();
         let parent = *tl.enter_stack.last().unwrap();
 
         let id = {
@@ -156,7 +192,7 @@ impl SpanGuard {
 
         tl.enter_stack.push(id);
 
-        tl.span_stack.push(crate::Span {
+        tl.spans.push(crate::Span {
             id,
             link: crate::Link::Parent { id: parent },
             begin_cycles: minstant::now(),
@@ -171,8 +207,8 @@ impl SpanGuard {
 impl Drop for SpanGuard {
     fn drop(&mut self) {
         let tl = unsafe { &mut *self.trace_local };
-        tl.span_stack[self.index].elapsed_cycles =
-            minstant::now().saturating_sub(tl.span_stack[self.index].begin_cycles);
+        tl.spans[self.index].elapsed_cycles =
+            minstant::now().saturating_sub(tl.spans[self.index].begin_cycles);
         tl.enter_stack.pop();
     }
 }


### PR DESCRIPTION
In some cases, an `event` is not enough for developers to get what they want during tracing. They may want to record some other information, e.g. host of the request, CPU usage.

For that, a mechanism is implemented to achieve that goal. Developers can attach information to the current span in bytes format:

```rust
let _guard = minitrace::new_span(event_id);
minitrace::property(info_bytes_0);
minitrace::property(info_bytes_1);
```

The property is in bytes format, so it is not limited to be a key-value pair but anything developers intend. However, the downside of flexibility is that encoding and decoding should be handled handly.