### PR TITLE
fix the inconsistence between cycles and realtime

### DIFF
--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -2,6 +2,7 @@
 
 mod common;
 use minitrace::prelude::*;
+use std::net::SocketAddr;
 
 #[derive(Debug)]
 enum AsyncJob {
@@ -65,12 +66,10 @@ async fn main() {
             })
         });
 
-        let agent = std::net::SocketAddr::from(([127, 0, 0, 1], 6831));
-        let _ = std::net::UdpSocket::bind(std::net::SocketAddr::new(
-            std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
-            0,
-        ))
-        .and_then(move |s| s.send_to(&buf, agent));
+        let local_addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
+        if let Ok(mut socket) = tokio::net::UdpSocket::bind(local_addr).await {
+            let _ = socket.send_to(&buf, "127.0.0.1:6831").await;
+        }
     }
 
     crate::common::draw_stdout(trace_results);

--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -44,8 +44,6 @@ async fn other_job() {
 
 #[tokio::main]
 async fn main() {
-    minitrace::init();
-
     let (trace_results, _) = async {
         minitrace::property(b"sample property:it works");
         let jhs = parallel_job();

--- a/examples/synchronous.rs
+++ b/examples/synchronous.rs
@@ -29,8 +29,6 @@ fn func2(i: u64) {
 }
 
 fn main() {
-    minitrace::init();
-
     let (root, collector) = minitrace::trace_enable(SyncJob::Root);
     minitrace::property(b"sample property:it works");
     {

--- a/src/future.rs
+++ b/src/future.rs
@@ -21,6 +21,7 @@ pub trait Instrument: Sized {
 
     #[inline]
     fn future_trace_enable<T: Into<u32>>(self, event: T) -> TraceRootFuture<Self> {
+        let now_cycles = minstant::now();
         let now = crate::time::real_time_ns();
         let collector = crate::collector::Collector::new(now);
 
@@ -29,6 +30,7 @@ pub trait Instrument: Sized {
             event: event.into(),
             crossthread_trace: crate::trace_crossthread::CrossthreadTrace::new_root(
                 collector.inner.clone(),
+                now_cycles,
             ),
             collector: Some(collector),
         }
@@ -41,6 +43,8 @@ pub trait Instrument: Sized {
         event: T,
     ) -> MayTraceRootFuture<Self> {
         if enable {
+            let now_cycles = minstant::now();
+
             let now = crate::time::real_time_ns();
             let collector = crate::collector::Collector::new(now);
             MayTraceRootFuture {
@@ -48,6 +52,7 @@ pub trait Instrument: Sized {
                 event: event.into(),
                 crossthread_trace: Some(crate::trace_crossthread::CrossthreadTrace::new_root(
                     collector.inner.clone(),
+                    now_cycles,
                 )),
                 collector: Some(collector),
             }

--- a/src/jaeger/mod.rs
+++ b/src/jaeger/mod.rs
@@ -551,8 +551,8 @@ mod zigzag {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn it_works() {
+    #[test]
+    fn it_works() {
         let res = {
             let (_g, collector) = crate::trace_enable(0u32);
             crate::property(b"test property:a root span");

--- a/src/jaeger/mod.rs
+++ b/src/jaeger/mod.rs
@@ -550,7 +550,6 @@ mod zigzag {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::SocketAddr;
 
     #[tokio::test]
     async fn it_works() {
@@ -580,16 +579,11 @@ mod tests {
             }
         });
 
-        let local_addr: SocketAddr = "0.0.0.0:0".parse().unwrap();
-        let socket_std = std::net::UdpSocket::bind(local_addr).unwrap();
-        let mut socket = tokio::net::UdpSocket::from_std(socket_std).unwrap();
-        socket.send_to(&buf, "127.0.0.1:6831").await.unwrap();
-
-        // let agent = std::net::SocketAddr::from(([127, 0, 0, 1], 6831));
-        // let _ = std::net::UdpSocket::bind(std::net::SocketAddr::new(
-        //     std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
-        //     0,
-        // ))
-        // .and_then(move |s| s.send_to(&buf, agent));
+        let agent = std::net::SocketAddr::from(([127, 0, 0, 1], 6831));
+        let _ = std::net::UdpSocket::bind(std::net::SocketAddr::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
+            0,
+        ))
+        .and_then(move |s| s.send_to(&buf, agent));
     }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -8,9 +8,9 @@ pub fn trace_enable<T: Into<u32>>(
     crate::trace_local::LocalTraceGuard,
     crate::collector::Collector,
 ) {
+    let now_cycles = minstant::now();
     let collector = crate::collector::Collector::new(crate::time::real_time_ns());
 
-    let now_cycles = minstant::now();
     let (trace_guard, _) = crate::trace_local::LocalTraceGuard::new(
         collector.inner.clone(),
         now_cycles,
@@ -42,12 +42,6 @@ pub fn trace_may_enable<T: Into<u32>>(
     } else {
         (None, None)
     }
-}
-
-/// Initialize time measuring infra. It's enough to call once.
-#[inline]
-pub fn init() {
-    minstant::now();
 }
 
 #[must_use]

--- a/src/trace_crossthread.rs
+++ b/src/trace_crossthread.rs
@@ -74,7 +74,7 @@ impl CrossthreadTrace {
                 inner.next_suspending_state = crate::State::Scheduling;
                 inner.next_related_id = self_id;
 
-                // Obviously, the begin cycles of the next suspending is impossible to predict, and it should 
+                // Obviously, the begin cycles of the next suspending is impossible to predict, and it should
                 // be recorded when `local_guard` is dropping. Here `LocalTraceGuard` is for this purpose.
                 // See `impl Drop for LocalTraceGuard`.
                 Some(LocalTraceGuard {


### PR DESCRIPTION
Signed-off-by: zhongzc <zhongzc_arch@outlook.com>

Previously, we roughly assumed that the continuous calls of `crate::time::real_time_ns()` and `minstant::now()` represents the same instant. However, that is not true when `minstall::now()` needs to initial. On my PC, the initialzation costs about 20ms then I'll always catch the time drift during testing needing initialzation constantly.

Here, I switch the order between them (i.e. `minstant::now()` first `crate::time::real_time_ns()` after) to eliminate the affect from the initialzation work.