### PR TITLE
Jaeger trace id can be specified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ minitrace-attribute = { path = "crates/attribute" }
 lazy_static = "1.4.0"
 crossbeam = "0.7"
 minstant = { git = "https://github.com/zhongzc/minstant.git" }
-rand = "0.7"
 
 [dependencies.futures_01]
 version = "0.1"
@@ -36,6 +35,7 @@ tracing-opentelemetry = "0.4"
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = "0.2"
+rand = "0.7"
 
 [[bench]]
 name = "trace"

--- a/README.md
+++ b/README.md
@@ -65,10 +65,9 @@ Threads:
 ```rust
 let (root, collector) = minitrace::trace_enable(0u32);
 
-let handle = minitrace::trace_binder();
+let mut handle = minitrace::trace_binder();
 
 let th = std::thread::spawn(move || {
-    let mut handle = handle;
     let _parent_guard = handle.trace_enable(1u32);
 
     {

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -56,12 +56,13 @@ fn minitrace_harness() {
         }
     }
 
-    let (root, collector) = minitrace::trace_enable(PARENT);
+    let collector = {
+        let (_guard, collector) = minitrace::trace_enable(PARENT);
 
-    {
-        let _guard = root;
         dummy_minitrace();
-    }
+
+        collector
+    };
 
     let _r = collector.collect();
 }

--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -23,14 +23,15 @@ fn trace_wide_bench(c: &mut Criterion) {
         "trace_wide",
         |b, len| {
             b.iter(|| {
-                let (root, collector) = minitrace::trace_enable(0u32);
-                {
-                    let _guard = root;
+                let collector = {
+                    let (_guard, collector) = minitrace::trace_enable(0u32);
 
                     if *len > 1 {
                         dummy_iter(*len);
                     }
-                }
+
+                    collector
+                };
 
                 let _r = black_box(collector.collect());
             });
@@ -44,15 +45,15 @@ fn trace_deep_bench(c: &mut Criterion) {
         "trace_deep",
         |b, len| {
             b.iter(|| {
-                let (root, collector) = minitrace::trace_enable(0u32);
-
-                {
-                    let _guard = root;
+                let collector = {
+                    let (_guard, collector) = minitrace::trace_enable(0u32);
 
                     if *len > 1 {
                         dummy_rec(*len);
                     }
-                }
+
+                    collector
+                };
 
                 let _r = black_box(collector.collect());
             });
@@ -61,5 +62,56 @@ fn trace_deep_bench(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benches, trace_wide_bench, trace_deep_bench);
+fn trace_future_bench(c: &mut Criterion) {
+    use minitrace::prelude::*;
+
+    async fn f(i: u32) {
+        for i in 0..i - 1 {
+            async {}.trace_async(black_box(i)).await
+        }
+    }
+
+    c.bench_function_over_inputs(
+        "trace_future",
+        |b, len| {
+            b.iter(|| {
+                let (collector, _) =
+                    futures_03::executor::block_on(f(*len).future_trace_enable(0u32));
+
+                black_box(collector.collect());
+            });
+        },
+        vec![1, 10, 100, 1000, 10000],
+    );
+}
+
+fn trace_start_context(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "trace_context",
+        |b, len| {
+            b.iter(|| {
+                let collector = {
+                    let (_guard, collector) = minitrace::trace_enable(0u32);
+
+                    for _i in 0..len - 1 {
+                        black_box(minitrace::trace_binder());
+                    }
+
+                    collector
+                };
+
+                black_box(collector.collect());
+            });
+        },
+        vec![1, 10, 100, 1000, 10000],
+    );
+}
+
+criterion_group!(
+    benches,
+    trace_wide_bench,
+    trace_deep_bench,
+    trace_future_bench,
+    trace_start_context,
+);
 criterion_main!(benches);

--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -65,6 +65,8 @@ async fn main() {
         minitrace::jaeger::thrift_compact_encode(
             &mut buf,
             "Async Example",
+            rand::random(),
+            rand::random(),
             &trace_details,
             |e| {
                 format!("{:?}", unsafe {

--- a/examples/synchronous.rs
+++ b/examples/synchronous.rs
@@ -46,6 +46,8 @@ fn main() {
         minitrace::jaeger::thrift_compact_encode(
             &mut buf,
             "Sync Example",
+            rand::random(),
+            rand::random(),
             &trace_details,
             |e| {
                 format!("{:?}", unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub struct Span {
 /// +--------------------------------------+
 /// |          A span with id 42           |
 /// +--------------------------------------+
-///       | let handle = trace_crossthread();
+///       | let handle = trace_binder();
 ///       | <- thread::spawn()
 ///       +-----------------------------------------+-------------------------------+
 ///       | state: Spawning, related_id: 42, id: 77 | state: Settle, related_id: 77 |

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -80,13 +80,12 @@ pub fn new_span<T: Into<u32>>(event: T) -> Option<crate::trace_local::SpanGuard>
 
 /// Bind the current tracing context to another executing context (e.g. a closure).
 ///
-/// ```no_run
+/// ```
 /// # use minitrace::trace_binder;
 /// # use std::thread;
 /// #
-/// let handle = trace_binder();
+/// let mut handle = trace_binder();
 /// thread::spawn(move || {
-///     let mut handle = handle;
 ///     let _g = handle.trace_enable(EVENT);
 /// });
 /// ```


### PR DESCRIPTION
Signed-off-by: zhongzc <zhongzc_arch@outlook.com>

- For reporting to Jaeger, we don't choose a unique trace id. Instead, it's left to fill as the user likes. Therefore, by specifying the same trace id, user can combine many tracing processes into one bigger context and view them on the same page.
- More bench cases, especially for `future`.
- Refactor tests.
- Fix a bug that a nested tracing context will ruin assumptions. Nested tracing context is baned.